### PR TITLE
heroku 배포 에러 수정

### DIFF
--- a/backend/system.properties
+++ b/backend/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=17


### PR DESCRIPTION
`java.runtime.version`을 명시적으로 설정해줘야 함